### PR TITLE
Insert Url class of path-util package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "puli/repository": "1.0.*",
         "puli/discovery": "^1.0.0-beta8",
         "webmozart/glob": ">=2.0,<4.0",
-        "webmozart/path-util": "dev-master"
+        "webmozart/path-util": "^2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.6",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "php": ">=5.3.9",
         "puli/repository": "1.0.*",
         "puli/discovery": "^1.0.0-beta8",
-        "webmozart/glob": ">=2.0,<4.0"
+        "webmozart/glob": ">=2.0,<4.0",
+        "webmozart/path-util": "dev-master"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.6",

--- a/src/DiscoveryUrlGenerator.php
+++ b/src/DiscoveryUrlGenerator.php
@@ -11,11 +11,13 @@
 
 namespace Puli\UrlGenerator;
 
+use InvalidArgumentException;
 use Puli\Discovery\Api\Discovery;
 use Puli\Discovery\Binding\ResourceBinding;
 use Puli\UrlGenerator\Api\CannotGenerateUrlException;
 use Puli\UrlGenerator\Api\UrlGenerator;
 use Webmozart\Glob\Glob;
+use Webmozart\PathUtil\Url;
 
 /**
  * A resource URL generator that uses a {@link ResourceDiscovery} as backend.
@@ -92,7 +94,14 @@ class DiscoveryUrlGenerator implements UrlGenerator
         $url = $this->generateUrlForBinding($matchedBinding, $repositoryPath);
 
         if ($currentUrl) {
-            // TODO use Url::makeRelative() once it exists
+            try {
+                $url = Url::makeRelative($url, $currentUrl);
+            } catch (InvalidArgumentException $e) {
+                throw new CannotGenerateUrlException(sprintf(
+                    'Cannot generate URL for "%s".',
+                    $repositoryPath
+                ), $e->getCode(), $e);
+            }
         }
 
         return $url;

--- a/src/DiscoveryUrlGenerator.php
+++ b/src/DiscoveryUrlGenerator.php
@@ -98,8 +98,8 @@ class DiscoveryUrlGenerator implements UrlGenerator
                 $url = Url::makeRelative($url, $currentUrl);
             } catch (InvalidArgumentException $e) {
                 throw new CannotGenerateUrlException(sprintf(
-                    'Cannot generate URL for "%s".',
-                    $repositoryPath
+                    'Cannot generate URL for "%s" to current url "%s".',
+                    $repositoryPath, $currentUrl
                 ), $e->getCode(), $e);
             }
         }

--- a/tests/DiscoveryUrlGeneratorTest.php
+++ b/tests/DiscoveryUrlGeneratorTest.php
@@ -223,7 +223,7 @@ class DiscoveryUrlGeneratorTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers DiscoveryUrlGenerator::generateUrl
+     * @covers \Puli\UrlGenerator\DiscoveryUrlGenerator::generateUrl
      */
     public function testGenerateUrlRelativeUrl()
     {
@@ -247,7 +247,7 @@ class DiscoveryUrlGeneratorTest extends PHPUnit_Framework_TestCase
     /**
      * @expectedException \Puli\UrlGenerator\Api\CannotGenerateUrlException
      * @expectedExceptionMessage Cannot generate URL for "/path/path/style.css" to current url "/".
-     * @covers DiscoveryUrlGenerator::generateUrl
+     * @covers \Puli\UrlGenerator\DiscoveryUrlGenerator::generateUrl
      */
     public function testMakeRelativeFails()
     {

--- a/tests/DiscoveryUrlGeneratorTest.php
+++ b/tests/DiscoveryUrlGeneratorTest.php
@@ -221,4 +221,50 @@ class DiscoveryUrlGeneratorTest extends PHPUnit_Framework_TestCase
 
         $this->generator->generateUrl('/path/path/style.css');
     }
+
+    /**
+     * @covers DiscoveryUrlGenerator::generateUrl
+     */
+    public function testGenerateUrlRelativeUrl()
+    {
+        $binding = new ResourceBinding(
+            '/path{,/**/*}',
+            DiscoveryUrlGenerator::BINDING_TYPE,
+            array(
+                DiscoveryUrlGenerator::SERVER_PARAMETER => 'localhost',
+                DiscoveryUrlGenerator::PATH_PARAMETER => '/css',
+            )
+        );
+
+        $this->discovery->expects($this->once())
+            ->method('findBindings')
+            ->with(DiscoveryUrlGenerator::BINDING_TYPE)
+            ->willReturn(array($binding));
+
+        $this->assertSame('path/style.css', $this->generator->generateUrl('/path/path/style.css', 'http://example.com/css'));
+    }
+
+    /**
+     * @expectedException \Puli\UrlGenerator\Api\CannotGenerateUrlException
+     * @expectedExceptionMessage Cannot generate URL for "/path/path/style.css" to current url "/".
+     * @covers DiscoveryUrlGenerator::generateUrl
+     */
+    public function testMakeRelativeFails()
+    {
+        $binding = new ResourceBinding(
+            '/path{,/**/*}',
+            DiscoveryUrlGenerator::BINDING_TYPE,
+            array(
+                DiscoveryUrlGenerator::SERVER_PARAMETER => 'localhost',
+                DiscoveryUrlGenerator::PATH_PARAMETER => '/css',
+            )
+        );
+
+        $this->discovery->expects($this->once())
+            ->method('findBindings')
+            ->with(DiscoveryUrlGenerator::BINDING_TYPE)
+            ->willReturn(array($binding));
+
+        $this->generator->generateUrl('/path/path/style.css', '/');
+    }
 }


### PR DESCRIPTION
I've added `Url::makeRelative` to `DiscoveryUrlGenerator::generateUrl` and handled the empty if-block for `$currentUrl`.

Because Url class of the path-util package will be released in a future version, I used dev-master in composer for the moment. I'll change this when webmozart/path-util will hit version 2.3, but for the moment, we can discuss about the new added code.
