### PR TITLE
Test enhancement

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -5,5 +5,4 @@ enabled:
     - strict
 
 disabled:
-    - empty_return
     - phpdoc_annotation_without_dot # This is still buggy: https://github.com/symfony/symfony/pull/19198

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,26 @@
 language: php
 
-sudo: false
-
 cache:
   directories:
     - $HOME/.composer/cache/files
 
 matrix:
   include:
-    - php: 5.3
-    - php: 5.4
-    - php: 5.5
-    - php: 5.6
-    - php: hhvm
     - php: nightly
     - php: 7.0
+    - php: 7.1
       env: COVERAGE=yes
-    - php: 7.0
+    - php: 7.1
+      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+    - php: 7.2
+      env: COVERAGE=yes
+    - php: 7.2
+      env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
+    - php: 7.3
+      env: COVERAGE=yes
+    - php: 7.3
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
   allow_failures:
-    - php: hhvm
     - php: nightly
   fast_finish: true
 

--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,15 @@
         }
     ],
     "require": {
-        "php": "^5.3.9|^7.0",
+        "php": "^7.0",
         "puli/repository": "^1.0-beta11@dev,<1.1",
         "puli/discovery": "^1.0.0-beta10@dev",
         "webmozart/glob": "^4.0",
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.6",
-        "sebastian/version": "^1.0.1"
+        "phpunit/phpunit": "^6.5",
+        "sebastian/version": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/DiscoveryUrlGenerator.php
+++ b/src/DiscoveryUrlGenerator.php
@@ -77,6 +77,7 @@ class DiscoveryUrlGenerator implements UrlGenerator
             /** @var ResourceBinding $binding */
             if (Glob::match($repositoryPath, $binding->getQuery())) {
                 $matchedBinding = $binding;
+
                 break;
             }
         }

--- a/tests/DiscoveryUrlGeneratorTest.php
+++ b/tests/DiscoveryUrlGeneratorTest.php
@@ -11,8 +11,7 @@
 
 namespace Puli\UrlGenerator\Tests;
 
-use PHPUnit_Framework_MockObject_MockObject;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Puli\Discovery\Api\Discovery;
 use Puli\Discovery\Api\Type\BindingParameter;
 use Puli\Discovery\Api\Type\BindingType;
@@ -27,12 +26,12 @@ use Puli\UrlGenerator\DiscoveryUrlGenerator;
  *
  * @author Bernhard Schussek <bschussek@gmail.com>
  */
-class DiscoveryUrlGeneratorTest extends PHPUnit_Framework_TestCase
+class DiscoveryUrlGeneratorTest extends TestCase
 {
     const RESOURCE_BINDING = 'Puli\Repository\Discovery\ResourceBinding';
 
     /**
-     * @var PHPUnit_Framework_MockObject_MockObject|Discovery
+     * @var PHPUnit\Framework\MockObject\MockObject|Discovery
      */
     private $discovery;
 
@@ -53,7 +52,8 @@ class DiscoveryUrlGeneratorTest extends PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->discovery = $this->getMock('Puli\Discovery\Api\Discovery');
+        $this->discovery = $this->getMockBuilder('Puli\Discovery\Api\Discovery');
+        $this->discovery = $this->discovery->getMock();
         $this->generator = new DiscoveryUrlGenerator($this->discovery, array(
             'localhost' => '/%s',
             'example.com' => 'https://example.com/%s',


### PR DESCRIPTION
# Changed log
- Drop `php-5.x` supports because they're not maintained by official PHP team.
- Remove the deprecated setting for StyleCI.
- Upgrade the PHPUnit version to support the `php-7.x` versions.
- The `getMock` is deprecated in latest stable PPHUnit version, and using the `getMockBuilder` instead.